### PR TITLE
Add ability to let users choose edge weight and node coloring

### DIFF
--- a/netwulf/interactive.py
+++ b/netwulf/interactive.py
@@ -218,7 +218,7 @@ def visualize(network,
         node[1].clear()
 
     with open(filepath,'w') as f:
-        json.dump(nx.node_link_data(net), f)
+        json.dump(nx.node_link_data(network), f)
 
     with open(configpath,'w') as f:
         json.dump(this_config, f)

--- a/netwulf/interactive.py
+++ b/netwulf/interactive.py
@@ -196,9 +196,9 @@ def visualize(network,
 
     network = network.copy()
 
-    for n1, n2, d in network.edges(data=True):
-        keep_value = d[edge_weight]
-        d.clear()
+    for n1, n2, edge in network.edges(data=True):
+        keep_value = edge[edge_weight]
+        edge.clear()
         network[n1][n2]['weight'] = keep_value
 
     if node_color is not None:
@@ -215,7 +215,8 @@ def visualize(network,
                 node[1].clear()
                 node[1]['group'] = keep_value
     else:
-        node[1].clear()
+        for node in network.nodes(data=True):
+            node[1].clear()
 
     with open(filepath,'w') as f:
         json.dump(nx.node_link_data(network), f)


### PR DESCRIPTION
As described in https://github.com/benmaier/netwulf/issues/2, this pull request adds two things:

1. The ability to choose which numerical edge attribute to use as the weight for the layout algo in the tool: By passing edge_weight='attribute' (default 'weight') to the visualize function the chosen (numerical) edge attribute will be exported to JSON as the weight of the edge.

2. The ability to choose the coloring of the nodes. This is done in a layered way: By passing node_color to visualize() with any other value than 'None' (which is the default and leads to the standard lime green being used for all nodes) the user gets two possible ways of assigning color: She could either specify a categorical node attribute encoded as a string inside each node, or pass a valid hex color directly.

This works as follows:

('Acinetobacter baumannii komplex',
 {'color': '#724c28',
  'type_': 'pathogen',
  'group': 'Acinetobacter baumannii Komplex'})

If 'color' is specified the value given must be a color (hex, rgb, ...) accepted by the tool. If a category like 'group' is given, the groups of all nodes will be enumerated and replaced with an integer for which the tool will choose a color automatically.

![screen shot 2018-10-23 at 22 13 54](https://user-images.githubusercontent.com/7582591/47387893-faaeac00-d710-11e8-9d0c-ecbeb784dc3a.png)
![screen shot 2018-10-23 at 22 13 45](https://user-images.githubusercontent.com/7582591/47387896-ff736000-d710-11e8-8b62-2de37110921f.png)

![screen shot 2018-10-23 at 22 15 16](https://user-images.githubusercontent.com/7582591/47387960-2fbafe80-d711-11e8-9f3d-2aa0e5440c73.png)
![screen shot 2018-10-23 at 22 15 02](https://user-images.githubusercontent.com/7582591/47387964-32b5ef00-d711-11e8-978c-de6a37adad3c.png)
