### PR TITLE
Don't trigger `draw_netwulf` on KeyboardInterrupt

### DIFF
--- a/netwulf/interactive.py
+++ b/netwulf/interactive.py
@@ -272,8 +272,12 @@ def visualize(network,
     try:
         while not server.end_requested:
             time.sleep(0.1)
+        is_keyboard_interrupted = False
     except KeyboardInterrupt:
+        is_keyboard_interrupted = True
         pass
+    
+    server.end_requested = True
 
     if verbose:
         print('stopping server ...')
@@ -297,9 +301,8 @@ def visualize(network,
         # apparently this is how it has to be on Windows
         is_jupyter = 'JPY_PARENT_PID' in env
 
-    if is_jupyter and server.end_requested:
+    if is_jupyter and not is_keyboard_interrupted:
         fig, ax = wulf.draw_netwulf(posted_network_properties)
-
 
     return posted_network_properties, posted_config
 

--- a/netwulf/interactive.py
+++ b/netwulf/interactive.py
@@ -275,8 +275,6 @@ def visualize(network,
     except KeyboardInterrupt:
         pass
 
-    server.end_requested = True
-
     if verbose:
         print('stopping server ...')
     server.stop_this()
@@ -299,7 +297,7 @@ def visualize(network,
         # apparently this is how it has to be on Windows
         is_jupyter = 'JPY_PARENT_PID' in env
 
-    if is_jupyter:
+    if is_jupyter and server.end_requested:
         fig, ax = wulf.draw_netwulf(posted_network_properties)
 
 


### PR DESCRIPTION
Maybe we can add in the future that keyboardinterrupt also pipes the network data back into Python, but for now this is necessary to not cause an error when doing keyboardinterrupt.