### PR TITLE
Change node position to be separate key-value pairs as opposed to `pos` vector

### DIFF
--- a/netwulf/tools.py
+++ b/netwulf/tools.py
@@ -22,8 +22,8 @@ def bind_positions_to_network(network, network_properties):
         interactive visualization.
     """
 
-    x =  { node['id']: node['pos'][0] for node in network_properties['nodes'] }
-    y =  { node['id']: node['pos'][1] for node in network_properties['nodes'] }
+    x = { node['id']: node['x'] for node in network_properties['nodes'] }
+    y = { node['id']: node['y'] for node in network_properties['nodes'] }
     nx.set_node_attributes(network, x, 'x')
     nx.set_node_attributes(network, y, 'y')
 
@@ -78,8 +78,8 @@ def draw_netwulf(network_properties, fig=None, ax=None, figsize=None):
     .. code:: python
 
         ax.text(
-                network_properties['nodes'][0]['pos'][0],
-                network_properties['nodes'][0]['pos'][1],
+                network_properties['nodes'][0]['x'],
+                network_properties['nodes'][0]['y'],
                 network_properties['nodes'][0]['id']
                )
 
@@ -144,15 +144,15 @@ def draw_netwulf(network_properties, fig=None, ax=None, figsize=None):
 
     # filter out node positions for links
     width = network_properties['xlim'][1] - network_properties['xlim'][0]
-    pos = { node['id']: np.array(node['pos']) for node in network_properties['nodes'] }
+    pos = { node['id']: np.array([node['x'], node['y']]) for node in network_properties['nodes'] }
 
     lines = []
     linewidths = []
     for link in network_properties['links']:
         u, v = link['link']
         lines.append([ 
-                        [pos[u][0],pos[v][0]], 
-                        [pos[u][1],pos[v][1]]
+            [pos[u][0], pos[v][0]], 
+            [pos[u][1], pos[v][1]]
                      ])
         linewidths.append(link['width']/width*axwidth)
 
@@ -175,7 +175,7 @@ def draw_netwulf(network_properties, fig=None, ax=None, figsize=None):
     node_colors = []
 
     for node in network_properties['nodes']:
-        XY.append( node['pos'] )
+        XY.append([node['x'], node['y']])
         # size has to be given in points**2
         size.append( 2*node['radius'] )
         node_colors.append(node['color'])


### PR DESCRIPTION
I made a minor change in the web-app so that when posting to Python the node position would be returned as x and y coordinates as opposed to a `pos` vector. This pull request just makes sure that the network can still be plotted with matplotlib after this change has been made.

The purpose is that the output format then resembles more the input one would provide to netwulf.visualize if one wanted to have fixed node positions, something I want to implement soon. So with this change, one can decide on a layout one likes, save the node-link dictionary and easily put it back into netwulf, maybe with different node colors or link structure.