### PR TITLE
rename netwulf alias from 'wulf' to' nw'

### DIFF
--- a/docs/cookbook/cookbook.rst
+++ b/docs/cookbook/cookbook.rst
@@ -6,7 +6,7 @@ Given a *networkx.Graph* object, you can launch netwulf like so:
 .. code:: python
 
 	import networkx as nx
-	import netwulf as wulf
+	import netwulf as nw
 
 	G = nx.barabasi_albert_graph(100, 2)
 
@@ -39,7 +39,7 @@ Example:
 
     import numpy as np
     import networkx as nx
-    import netwulf as wulf
+    import netwulf as nw
 
     # Create a network
     G = nx.random_partition_graph([10, 10, 10], .25, .01)
@@ -61,7 +61,7 @@ Example:
     for n1, n2, data in G.edges(data=True):
         data['weight'] = np.random.random()
 
-    wulf.visualize(G)
+    nw.visualize(G)
 
 
 .. figure:: img/random_partition_graph.png
@@ -94,14 +94,14 @@ Save as PDF
 .. code:: python
 
     import networkx as nx
-    import netwulf as wulf
+    import netwulf as nw
     import matplotlib.pyplot as plt
     
     G = nx.barabasi_albert_graph(100, 2)
     
-    network, config = wulf.visualize(G, plot_in_cell_below=False)
+    network, config = nw.visualize(G, plot_in_cell_below=False)
     
-    fig, ax = wulf.draw_netwulf(network, figsize=(10,10))
+    fig, ax = nw.draw_netwulf(network, figsize=(10,10))
     plt.savefig("myfigure.pdf")
 
 
@@ -111,28 +111,28 @@ Labels and node positions
 .. code:: python
 
     import networkx as nx
-    import netwulf as wulf
+    import netwulf as nw
     import matplotlib.pyplot as plt
 
     G = nx.Graph()
     G.add_nodes_from([0,1,2,'a','b','c'])
     G.add_edges_from([(0,1),('a','b')])
 
-    network, config = wulf.visualize(G,config={'zoom':3})
+    network, config = nw.visualize(G,config={'zoom':3})
 
     # draw links only at first
-    fig, ax = wulf.draw_netwulf(network,draw_nodes=False)
+    fig, ax = nw.draw_netwulf(network,draw_nodes=False)
 
     # get positions of two unconnected nodes to draw a link anyway
-    v0 = wulf.node_pos(network, 'c')
-    v1 = wulf.node_pos(network, 2)
+    v0 = nw.node_pos(network, 'c')
+    v1 = nw.node_pos(network, 2)
     ax.plot([v0[0],v1[0]],[v0[1],v1[1]],c='#d95f02')
 
     # draw nodes now
-    wulf.draw_netwulf(network,fig,ax,draw_links=False)
+    nw.draw_netwulf(network,fig,ax,draw_links=False)
 
     # add labels to a node and an edge
-    wulf.add_node_label(ax,network,'c')
-    wulf.add_edge_label(ax,network,('a','b'))
+    nw.add_node_label(ax,network,'c')
+    nw.add_edge_label(ax,network,('a','b'))
     
 .. figure:: img/labeled_graph.png

--- a/docs/python_api/data_io.rst
+++ b/docs/python_api/data_io.rst
@@ -9,19 +9,19 @@ Start a visualization like this
 .. code:: python
 
     import networkx as nx
-    import netwulf as wulf
+    import netwulf as nw
 
     G = nx.barabasi_albert_graph(100,2)
 
-    stylized_network, config = wulf.visualize(G)
+    stylized_network, config = nw.visualize(G)
 
 You can either save/load the stylized network only
 
 .. code:: python
 
-    wulf.save("BA.json", stylized_network, config)
-    stylized_network, config, _ = wulf.load("BA.json")
-    wulf.draw_netwulf(stylized_network, config)
+    nw.save("BA.json", stylized_network, config)
+    stylized_network, config, _ = nw.load("BA.json")
+    nw.draw_netwulf(stylized_network, config)
 
 
 Or you can save/load with the respective ``networkx.Graph``-object
@@ -29,6 +29,6 @@ in order to replicate some other features.
 
 .. code:: python
 
-    wulf.save("BA.json", stylized_network, config, G)
-    stylized_network, config, G = wulf.load("BA.json")
+    nw.save("BA.json", stylized_network, config, G)
+    stylized_network, config, G = nw.load("BA.json")
 

--- a/docs/python_api/drawing.rst
+++ b/docs/python_api/drawing.rst
@@ -8,14 +8,14 @@ the function :mod:`netwulf.tools.draw_netwulf`.
 .. code:: python
 
     import networkx as nx
-    import netwulf as wulf
+    import netwulf as nw
 
     G = nx.barabasi_albert_graph(100,1)
 
-    stylized_network, config = wulf.visualize(G)
+    stylized_network, config = nw.visualize(G)
 
     import matplotlib.pyplot as plt
-    fig, ax = wulf.draw_netwulf(stylized_network)
+    fig, ax = nw.draw_netwulf(stylized_network)
     plt.show()
 
 

--- a/docs/python_api/network_manipulation.rst
+++ b/docs/python_api/network_manipulation.rst
@@ -14,7 +14,7 @@ will be grouped and colored in the visualization. Here's an example
 .. code:: python
 
     import networkx as nx
-    import netwulf as wulf
+    import netwulf as nw
 
     import numpy as np
 
@@ -26,8 +26,8 @@ will be grouped and colored in the visualization. Here's an example
         G[u][v]['bar'] = np.random.rand()
 
     # filter the Graph to visualize one where the weight is determined by 'foo'
-    new_G = wulf.get_filtered_network(G,edge_weight_key='foo')
-    wulf.visualize(new_G)
+    new_G = nw.get_filtered_network(G,edge_weight_key='foo')
+    nw.visualize(new_G)
 
     # assign node attributes according to some generic grouping 
     grp = {u: 'ABCDE'[u%5]  for u in G.nodes() }
@@ -35,8 +35,8 @@ will be grouped and colored in the visualization. Here's an example
 
     # filter the Graph to visualize one where the weight is determined by 'bar'
     # and the node group (coloring) is determined by the node attribute 'wum'
-    new_G = wulf.get_filtered_network(G,edge_weight_key='bar',node_group_key='wum')
-    wulf.visualize(new_G)
+    new_G = nw.get_filtered_network(G,edge_weight_key='bar',node_group_key='wum')
+    nw.visualize(new_G)
 
 Binding positions
 ~~~~~~~~~~~~~~~~~
@@ -47,7 +47,7 @@ where you left off last time, you can bind the positions to the network
 
 .. code:: python
 
-    wulf.bind_positions_to_network(G, stylized_network)
+    nw.bind_positions_to_network(G, stylized_network)
 
 There's no return value and the positions are directly written to the Graph-object ``G``.
 

--- a/docs/python_api/post_back.rst
+++ b/docs/python_api/post_back.rst
@@ -12,11 +12,11 @@ Start a visualization like this
 .. code:: python
 
     import networkx as nx
-    import netwulf as wulf
+    import netwulf as nw
 
     G = nx.barabasi_albert_graph(100,2)
 
-    stylized_network, config = wulf.visualize(G)
+    stylized_network, config = nw.visualize(G)
 
 
 A visualization window is opened and the network can be stylized.
@@ -128,4 +128,4 @@ again with, passing the produced configuration.
 
 .. code:: python
 
-    wulf.visualize(G, config=config)
+    nw.visualize(G, config=config)


### PR DESCRIPTION
As the title says. I think a two letter alias line `nw` is stronger than `wulf`. Changes only made to the docs.