### PR TITLE
Run tests on GitHub Actions CI on Linux under xvfb

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: '0 6 * * *'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          # would need custom setup to install browser and xvfb
+          # - windows-2019
+          # - macos-latest
+        python:
+          - 3.7
+          - 3.8
+          - 3.9
+          - '3.10'  # Needs quotes so YAML doesn't think it's 3.1
+    steps:
+    - name: Set up environment
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install -e "."
+        pip install pytest pytest-cov
+        sudo apt-get install xvfb chromium-browser
+
+    - name: Run all tests
+      run: |
+         xvfb-run --auto-servernum --server-num=20 python -m pytest -s -v --cov=netwulf netwulf/tests/test_all.py
+
+    # TODO for enthusiast to add token to secrets and upload coverage
+    #- name: Upload coverage to Codecov
+    #  uses: codecov/codecov-action@v3
+    #  with:
+    #    token: ${{ secrets.CODECOV_TOKEN }}
+    #    file: ./coverage.xml
+    #    flags: unittests
+    #    # name: codecov-umbrella
+    #    # yml: ./codecov.yml
+    #    fail_ci_if_error: false


### PR DESCRIPTION
You can see results under https://github.com/yarikoptic/netwulf/actions/runs/4030268950/jobs/6928824343 -- seems to pass for all Pythons. I made up this workflow from the one we have in dandi-cli and kept some blocks commented out for possible future extensions. Cheers,